### PR TITLE
Redux refactor

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -1,65 +1,160 @@
-/**
-@license
-Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
-*/
+import {
+  navigate,
+  showSnackbar,
+  updateOffline } from './domains/page.js';
 
-export const UPDATE_PAGE = 'UPDATE_PAGE';
-export const UPDATE_OFFLINE = 'UPDATE_OFFLINE';
-export const OPEN_SNACKBAR = 'OPEN_SNACKBAR';
-export const CLOSE_SNACKBAR = 'CLOSE_SNACKBAR';
+import {
+  showInGameMenu,
+  hideInGameMenu,
+  resetGame } from './domains/game.js';
 
-export const navigate = (path) => (dispatch) => {
-  // Extract the page name from path.
-  const page = path === '/' ? 'game' : path.slice(1);
+import {
+  spendAllocatedEnergy,
+  allocateEnergy,
+  cancelAllocateEnergy } from './domains/status.js';
 
-  // Any other info you might want to extract from the path (like page type),
-  // you can do here
-  dispatch(loadPage(page));
-};
+import {
+  recordAttackCard,
+  recordPlaceOnPlayArea,
+  recordCastFromHand,
+  recordCastFromPlayArea,
+  recordCastAbilityEnergize,
+  endTurn } from './domains/turnaction.js';
 
-const loadPage = (page) => async (dispatch) => {
-  switch(page) {
-    case 'game':
-      await import('../app/pages/cc-game-page.js');
-      break;
-    case 'about':
-      await import('../app/pages/cc-about-page.js');
-      break;
-    default:
-      page = 'view404';
-      await import('../app/pages/cc-view404.js');
-      break;
-  }
-  dispatch(updatePage(page));
+import {
+  selectHandCard,
+  cancelSelectHandCard,
+  playSelectedHandCard,
+  cancelPlaySelectedHandCard,
+  placeOnPlayArea,
+  playFromPlayArea,
+  cancelPlayFromPlayArea,
+  selectOpponentFieldCard,
+  cancelSelectOpponentFieldCard,
+  selectPlayerFieldCard,
+  cancelSelectPlayerFieldCard,
+  attackCard,
+  clearHand,
+  cancelCastingCard,
+  finishCastingCard } from './domains/card.js';
+
+
+export const Navigate = (path) => (dispatch) => {
+  dispatch(navigate(path))
 }
 
-const updatePage = (page) => {
-  return {
-    type: UPDATE_PAGE,
-    page
-  };
+export const ShowSnackbar = () => (dispatch) => {
+  dispatch(showSnackbar())
 }
 
-let snackbarTimer;
+export const UpdateOffline = (offline) => (dispatch) => {
+  dispatch(updateOffline(offline))
+}
 
-export const showSnackbar = () => (dispatch) => {
-  dispatch({
-    type: OPEN_SNACKBAR
-  });
-  clearTimeout(snackbarTimer);
-  snackbarTimer = setTimeout(() =>
-    dispatch({ type: CLOSE_SNACKBAR }), 3000);
-};
+export const ShowInGameMenu = () => (dispatch) => {
+  dispatch(showInGameMenu())
+}
 
-export const updateOffline = (offline) => {
-  return {
-    type: UPDATE_OFFLINE,
-    offline
-  };
-};
+export const HideInGameMenu = () => (dispatch) => {
+  dispatch(hideInGameMenu())
+}
 
+export const ResetGame = () => (dispatch) => {
+  dispatch(resetGame())
+}
+
+export const SpendAllocatedEnergy = () => (dispatch) => {
+  dispatch(spendAllocatedEnergy())
+}
+
+export const AllocateEnergy = (energyCost) => (dispatch) => {
+  dispatch(allocateEnergy(energyCost))
+}
+
+export const CancelAllocateEnergy = () => (dispatch) => {
+  dispatch(cancelAllocateEnergy())
+}
+
+export const RecordAttackCard = (playerFieldCardIndex, opponentFieldCardIndex) => (dispatch) => {
+  dispatch(recordAttackCard(playerFieldCardIndex, opponentFieldCardIndex))
+}
+
+export const RecordPlaceOnPlayArea = (playerFieldCardIndex, handCardIndex) => (dispatch) => {
+  dispatch(recordPlaceOnPlayArea(playerFieldCardIndex, handCardIndex))
+}
+
+export const RecordCastFromHand = (cardId, cardInstance, handCardIndex) => (dispatch) => {
+  dispatch(recordCastFromHand(cardId, cardInstance, handCardIndex))
+}
+
+export const RecordCastFromPlayArea = (cardId, cardInstance, playerFieldCardIndex) => (dispatch) => {
+  dispatch(recordCastFromPlayArea(cardId, cardInstance, playerFieldCardIndex))
+}
+
+export const RecordCastAbilityEnergize = (cardId, cardInstance, playerFieldCardIndex) => (dispatch) => {
+  dispatch(recordCastAbilityEnergize(cardId, cardInstance, playerFieldCardIndex))
+}
+
+export const EndTurn = (turn) => (dispatch) => {
+  dispatch(endTurn(turn))
+}
+
+export const SelectHandCard = (cardId, cardInstance, handIndex) => (dispatch) => {
+  dispatch(selectHandCard(cardId, cardInstance, handIndex))
+}
+
+export const CancelSelectHandCard = () => (dispatch) => {
+  dispatch(cancelSelectHandCard())
+}
+
+export const PlaySelectedHandCard = () => (dispatch) => {
+  dispatch(playSelectedHandCard())
+}
+
+export const CancelPlaySelectedHandCard = () => (dispatch) => {
+  dispatch(cancelPlaySelectedHandCard())
+}
+
+export const PlaceOnPlayArea = (playAreaIndex) => (dispatch) => {
+  dispatch(placeOnPlayArea(playAreaIndex))
+}
+
+export const PlayFromPlayArea = (playAreaIndex) => (dispatch) => {
+  dispatch(playFromPlayArea(playAreaIndex))
+}
+
+export const CancelPlayFromPlayArea = () => (dispatch) => {
+  dispatch(cancelPlayFromPlayArea())
+}
+
+export const SelectOpponentFieldCard = (playAreaIndex) => (dispatch) => {
+  dispatch(selectOpponentFieldCard(playAreaIndex))
+}
+
+export const CancelSelectOpponentFieldCard = () => (dispatch) => {
+  dispatch(cancelSelectOpponentFieldCard())
+}
+
+export const SelectPlayerFieldCard = (playAreaIndex) => (dispatch) => {
+  dispatch(selectPlayerFieldCard(playAreaIndex))
+}
+
+export const CancelSelectPlayerFieldCard = () => (dispatch) => {
+  dispatch(cancelSelectPlayerFieldCard())
+}
+
+export const AttackCard = (playAreaIndex) => (dispatch) => {
+  dispatch(attackCard(playAreaIndex))
+}
+
+export const ClearHand = () => (dispatch) => {
+  dispatch(clearHand())
+}
+
+export const CancelCastingCard = () => (dispatch) => {
+  dispatch(cancelCastingCard())
+}
+
+export const FinishCastingCard = () => (dispatch) => {
+  dispatch(finishCastingCard())
+}

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -1,3 +1,7 @@
+import { store } from '../store.js';
+
+import { GetCard } from '../util/card.js';
+
 import {
   navigate,
   showSnackbar,
@@ -83,6 +87,7 @@ export const HideInGameMenu = () => (dispatch) => {
 }
 
 export const ResetGame = () => (dispatch) => {
+  dispatch(HideInGameMenu())
   dispatch(resetGame())
   CallStartGame()
   .then((initialGame) => {
@@ -103,39 +108,13 @@ export const ResetGame = () => (dispatch) => {
 
 }
 
-export const SpendAllocatedEnergy = () => (dispatch) => {
-  dispatch(spendAllocatedEnergy())
+function _getDeepCopy(obj) {
+  return JSON.parse(JSON.stringify(obj))
 }
 
-export const AllocateEnergy = (energyCost) => (dispatch) => {
-  dispatch(allocateEnergy(energyCost))
-}
-
-export const CancelAllocateEnergy = () => (dispatch) => {
-  dispatch(cancelAllocateEnergy())
-}
-
-export const RecordAttackCard = (playerFieldCardIndex, opponentFieldCardIndex) => (dispatch) => {
-  dispatch(recordAttackCard(playerFieldCardIndex, opponentFieldCardIndex))
-}
-
-export const RecordPlaceOnPlayArea = (playerFieldCardIndex, handCardIndex) => (dispatch) => {
-  dispatch(recordPlaceOnPlayArea(playerFieldCardIndex, handCardIndex))
-}
-
-export const RecordCastFromHand = (cardId, cardInstance, handCardIndex) => (dispatch) => {
-  dispatch(recordCastFromHand(cardId, cardInstance, handCardIndex))
-}
-
-export const RecordCastFromPlayArea = (cardId, cardInstance, playerFieldCardIndex) => (dispatch) => {
-  dispatch(recordCastFromPlayArea(cardId, cardInstance, playerFieldCardIndex))
-}
-
-export const RecordCastAbilityEnergize = (cardId, cardInstance, playerFieldCardIndex) => (dispatch) => {
-  dispatch(recordCastAbilityEnergize(cardId, cardInstance, playerFieldCardIndex))
-}
-
-export const EndTurn = (turn) => (dispatch) => {
+export const EndTurn = () => (dispatch) => {
+  dispatch(clearHand())
+  const turn = _getDeepCopy(store.getState().turnaction.pendingTurn)
   dispatch(endTurn())
   CallEndTurn(turn)
   .then(results => {
@@ -179,14 +158,20 @@ export const CancelSelectHandCard = () => (dispatch) => {
 }
 
 export const PlaySelectedHandCard = () => (dispatch) => {
+  const selectedCard = store.getState().card.selectedHandCard
+  const card = GetCard(store.getState().card.cards, selectedCard.id, selectedCard.instance)
+  dispatch(allocateEnergy(card.cost))
   dispatch(playSelectedHandCard())
 }
 
 export const CancelPlaySelectedHandCard = () => (dispatch) => {
+  dispatch(cancelAllocateEnergy())
   dispatch(cancelPlaySelectedHandCard())
 }
 
 export const PlaceOnPlayArea = (playAreaIndex) => (dispatch) => {
+  dispatch(spendAllocatedEnergy())
+  dispatch(recordPlaceOnPlayArea(playAreaIndex, store.getState().card.playFromHand.handIndex))
   dispatch(placeOnPlayArea(playAreaIndex))
 }
 
@@ -215,17 +200,28 @@ export const CancelSelectPlayerFieldCard = () => (dispatch) => {
 }
 
 export const AttackCard = (playAreaIndex) => (dispatch) => {
+  dispatch(recordAttackCard(store.getState().card.playFromPlayArea.playAreaIndex, playAreaIndex))
   dispatch(attackCard(playAreaIndex))
 }
 
-export const ClearHand = () => (dispatch) => {
-  dispatch(clearHand())
+export const CastFromHand = (cardId, cardInstance, handCardIndex) => (dispatch) => {
+  dispatch(recordCastFromHand(cardId, cardInstance, handCardIndex))
+}
+
+export const CastFromPlayArea = (cardId, cardInstance, playerFieldCardIndex) => (dispatch) => {
+  dispatch(recordCastFromPlayArea(cardId, cardInstance, playerFieldCardIndex))
+}
+
+export const CastAbilityEnergize = (cardId, cardInstance, playerFieldCardIndex) => (dispatch) => {
+  dispatch(recordCastAbilityEnergize(cardId, cardInstance, playerFieldCardIndex))
 }
 
 export const CancelCastingCard = () => (dispatch) => {
+  dispatch(cancelAllocateEnergy())
   dispatch(cancelCastingCard())
 }
 
 export const FinishCastingCard = () => (dispatch) => {
+  dispatch(spendAllocatedEnergy())
   dispatch(finishCastingCard())
 }

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -204,16 +204,25 @@ export const AttackCard = (playAreaIndex) => (dispatch) => {
   dispatch(attackCard(playAreaIndex))
 }
 
-export const CastFromHand = (cardId, cardInstance, handCardIndex) => (dispatch) => {
-  dispatch(recordCastFromHand(cardId, cardInstance, handCardIndex))
+export const CastAbilityEnergize = (abilityId) => (dispatch) => {
+  _recordCastFromPosition(dispatch)
+  dispatch(recordCastAbilityEnergize(abilityId))
 }
 
-export const CastFromPlayArea = (cardId, cardInstance, playerFieldCardIndex) => (dispatch) => {
-  dispatch(recordCastFromPlayArea(cardId, cardInstance, playerFieldCardIndex))
-}
-
-export const CastAbilityEnergize = (cardId, cardInstance, playerFieldCardIndex) => (dispatch) => {
-  dispatch(recordCastAbilityEnergize(cardId, cardInstance, playerFieldCardIndex))
+function _recordCastFromPosition(dispatch) {
+  const selectedCastingCard = store.getState().card.selectedCastingCard
+  const cardId = selectedCastingCard.id
+  const cardInstance = selectedCastingCard.instance
+  const handIndex = selectedCastingCard.handIndex
+  const playAreaIndex = selectedCastingCard.playAreaIndex
+  if (handIndex === 0 || handIndex) {
+    dispatch(recordCastFromHand(cardId, cardInstance, handIndex))
+  } else if (playAreaIndex === 0 || playAreaIndex) {
+    dispatch(recordCastFromPlayArea(cardId, cardInstance, playAreaIndex))
+  } else {
+    console.error('Unexpected casting origin: not from hand nor play area.')
+    return
+  }
 }
 
 export const CancelCastingCard = () => (dispatch) => {

--- a/src/actions/domains/card.js
+++ b/src/actions/domains/card.js
@@ -23,7 +23,7 @@ export const FINISH_CASTING_CARD = 'FINISH_CASTING_CARD';
 export const CAST_CARD_FROM_HAND = 'CAST_CARD_FROM_HAND';
 export const CAST_CARD_FROM_PLAY_AREA = 'CAST_CARD_FROM_PLAY_AREA';
 
-export const SelectHandCard = (cardId, cardInstance, handIndex) => {
+export const selectHandCard = (cardId, cardInstance, handIndex) => {
   return {
     type: SELECT_HAND_CARD,
     cardId,
@@ -32,84 +32,84 @@ export const SelectHandCard = (cardId, cardInstance, handIndex) => {
   }
 };
 
-export const CancelSelectHandCard = () => {
+export const cancelSelectHandCard = () => {
   return {
     type: CANCEL_SELECT_HAND_CARD
   }
 };
 
-export const PlaySelectedHandCard = () => {
+export const playSelectedHandCard = () => {
   return {
     type: PLAY_SELECTED_HAND_CARD
   }
 };
 
-export const CancelPlaySelectedHandCard = () => {
+export const cancelPlaySelectedHandCard = () => {
   return {
     type: CANCEL_PLAY_SELECTED_HAND_CARD
   }
 };
 
-export const PlaceOnPlayArea = (playAreaIndex) => {
+export const placeOnPlayArea = (playAreaIndex) => {
   return {
     type: PLACE_ON_PLAY_AREA,
     playAreaIndex
   }
 };
 
-export const PlayFromPlayArea = (playAreaIndex) => {
+export const playFromPlayArea = (playAreaIndex) => {
   return {
     type: PLAY_FROM_PLAY_AREA,
     playAreaIndex
   }
 };
 
-export const CancelPlayFromPlayArea = () => {
+export const cancelPlayFromPlayArea = () => {
   return {
     type: CANCEL_PLAY_FROM_PLAY_AREA
   }
 };
 
-export const SelectOpponentFieldCard = (playAreaIndex) => {
+export const selectOpponentFieldCard = (playAreaIndex) => {
   return {
     type: SELECT_OPPONENT_FIELD_CARD,
     playAreaIndex
   }
 }
 
-export const CancelSelectOpponentFieldCard = () => {
+export const cancelSelectOpponentFieldCard = () => {
   return {
     type: CANCEL_SELECT_OPPONENT_FIELD_CARD
   }
 }
 
-export const SelectPlayerFieldCard = (playAreaIndex) => {
+export const selectPlayerFieldCard = (playAreaIndex) => {
   return {
     type: SELECT_PLAYER_FIELD_CARD,
     playAreaIndex
   }
 }
 
-export const CancelSelectPlayerFieldCard = () => {
+export const cancelSelectPlayerFieldCard = () => {
   return {
     type: CANCEL_SELECT_PLAYER_FIELD_CARD
   }
 }
 
-export const AttackCard = (playAreaIndex) => {
+export const attackCard = (playAreaIndex) => {
   return {
     type: ATTACK_CARD,
     playAreaIndex
   }
 }
 
-export const ClearHand = () => {
+export const clearHand = () => {
   return {
     type: CLEAR_HAND
   }
 }
 
-export const SetHand = ({hand, deckSize, discardPileSize, lostCardsSize}) => {
+export const setHand = ({hand, deckSize, discardPileSize, lostCardsSize}) => {
   return {
     type: SET_HAND,
     hand,
@@ -119,20 +119,20 @@ export const SetHand = ({hand, deckSize, discardPileSize, lostCardsSize}) => {
   }
 }
 
-export const RefreshCards = () => {
+export const refreshCards = () => {
   return {
     type: REFRESH_CARDS
   }
 }
 
-export const SetCards = (cards) => {
+export const setCards = (cards) => {
   return {
     type: SET_CARDS,
     cards
   }
 }
 
-export const SetOpponentField = ({opponentField, opponentFieldBacklog, opponentFieldCards}) => {
+export const setOpponentField = ({opponentField, opponentFieldBacklog, opponentFieldCards}) => {
   return {
     type: SET_OPPONENT_FIELD,
     opponentField,
@@ -141,26 +141,26 @@ export const SetOpponentField = ({opponentField, opponentFieldBacklog, opponentF
   }
 }
 
-export const SetFieldFromOpponentTurn = (opponentTurn) => {
+export const setFieldFromOpponentTurn = (opponentTurn) => {
   return {
     type: SET_FIELD_FROM_OPPONENT_TURN,
     opponentTurn
   }
 }
 
-export const ResetCards = () => {
+export const resetCards = () => {
   return {
     type: RESET_CARDS
   }
 }
 
-export const CancelCastingCard = () => {
+export const cancelCastingCard = () => {
   return {
     type: CANCEL_CASTING_CARD
   }
 }
 
-export const FinishCastingCard = () => {
+export const finishCastingCard = () => {
   return {
     type: FINISH_CASTING_CARD
   }

--- a/src/actions/domains/game.js
+++ b/src/actions/domains/game.js
@@ -1,23 +1,3 @@
-import {
-  CallStartGame } from '../../services/turnaction.js';
-
-import { 
-  CallGetCards,
-  CallGetHand,
-  CallGetOpponentField } from '../../services/card.js';
-
-import {
-  setStatus } from './status.js';
-
-import {
-  resetCards,
-  setCards,
-  setHand,
-  setOpponentField } from './card.js';
-
-import {
-  resetTurns } from './turnaction.js';
-
 export const SHOW_IN_GAME_MENU = 'SHOW_IN_GAME_MENU';
 export const HIDE_IN_GAME_MENU = 'HIDE_IN_GAME_MENU';
 export const RESET_GAME = 'RESET_GAME';
@@ -37,30 +17,10 @@ export const hideInGameMenu = () => {
 };
 
 export const resetGame = () => (dispatch) => {
-  dispatch(_resetGame())
-  CallStartGame()
-  .then((initialGame) => {
-    dispatch(setStatus(initialGame.status))
-    dispatch(resetCards())
-    dispatch(resetTurns())
-    Promise.all([CallGetCards(), CallGetHand(), CallGetOpponentField()])
-    .then(results => {
-      dispatch(setCards(results[0]))
-      dispatch(setHand(results[1]))
-      dispatch(setOpponentField(results[2]))
-    })
-    .catch(err => {
-      console.error(err)
-    })
-  })
-  .catch(err => console.error(err))
-};
-
-const _resetGame = () => {
   return {
     type: RESET_GAME
   }
-}
+};
 
 export const winGame = () => {
   return {

--- a/src/actions/domains/game.js
+++ b/src/actions/domains/game.js
@@ -16,7 +16,7 @@ export const hideInGameMenu = () => {
   }
 };
 
-export const resetGame = () => (dispatch) => {
+export const resetGame = () => {
   return {
     type: RESET_GAME
   }

--- a/src/actions/domains/game.js
+++ b/src/actions/domains/game.js
@@ -1,22 +1,22 @@
 import {
-  CallStartGame } from '../services/turnaction.js';
+  CallStartGame } from '../../services/turnaction.js';
 
 import { 
   CallGetCards,
   CallGetHand,
-  CallGetOpponentField } from '../services/card.js';
+  CallGetOpponentField } from '../../services/card.js';
 
 import {
-  SetStatus } from './status.js';
+  setStatus } from './status.js';
 
 import {
-  ResetCards,
-  SetCards,
-  SetHand,
-  SetOpponentField } from './card.js';
+  resetCards,
+  setCards,
+  setHand,
+  setOpponentField } from './card.js';
 
 import {
-  ResetTurns } from './turnaction.js';
+  resetTurns } from './turnaction.js';
 
 export const SHOW_IN_GAME_MENU = 'SHOW_IN_GAME_MENU';
 export const HIDE_IN_GAME_MENU = 'HIDE_IN_GAME_MENU';
@@ -24,30 +24,30 @@ export const RESET_GAME = 'RESET_GAME';
 export const WIN_GAME = 'WIN_GAME';
 export const LOSE_GAME = 'LOSE_GAME';
 
-export const ShowInGameMenu = () => {
+export const showInGameMenu = () => {
   return {
     type: SHOW_IN_GAME_MENU
   }
 };
 
-export const HideInGameMenu = () => {
+export const hideInGameMenu = () => {
   return {
     type: HIDE_IN_GAME_MENU
   }
 };
 
-export const ResetGame = () => (dispatch) => {
+export const resetGame = () => (dispatch) => {
   dispatch(_resetGame())
   CallStartGame()
   .then((initialGame) => {
-    dispatch(SetStatus(initialGame.status))
-    dispatch(ResetCards())
-    dispatch(ResetTurns())
+    dispatch(setStatus(initialGame.status))
+    dispatch(resetCards())
+    dispatch(resetTurns())
     Promise.all([CallGetCards(), CallGetHand(), CallGetOpponentField()])
     .then(results => {
-      dispatch(SetCards(results[0]))
-      dispatch(SetHand(results[1]))
-      dispatch(SetOpponentField(results[2]))
+      dispatch(setCards(results[0]))
+      dispatch(setHand(results[1]))
+      dispatch(setOpponentField(results[2]))
     })
     .catch(err => {
       console.error(err)
@@ -62,13 +62,13 @@ const _resetGame = () => {
   }
 }
 
-export const WinGame = () => {
+export const winGame = () => {
   return {
     type: WIN_GAME
   }
 }
 
-export const LoseGame = () => {
+export const loseGame = () => {
   return {
     type: LOSE_GAME
   }

--- a/src/actions/domains/page.js
+++ b/src/actions/domains/page.js
@@ -1,0 +1,65 @@
+/**
+@license
+Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+
+export const UPDATE_PAGE = 'UPDATE_PAGE';
+export const UPDATE_OFFLINE = 'UPDATE_OFFLINE';
+export const OPEN_SNACKBAR = 'OPEN_SNACKBAR';
+export const CLOSE_SNACKBAR = 'CLOSE_SNACKBAR';
+
+export const navigate = (path) => (dispatch) => {
+  // Extract the page name from path.
+  const page = path === '/' ? 'game' : path.slice(1);
+
+  // Any other info you might want to extract from the path (like page type),
+  // you can do here
+  dispatch(loadPage(page));
+};
+
+const loadPage = (page) => async (dispatch) => {
+  switch(page) {
+    case 'game':
+      await import('../../app/pages/cc-game-page.js');
+      break;
+    case 'about':
+      await import('../../app/pages/cc-about-page.js');
+      break;
+    default:
+      page = 'view404';
+      await import('../../app/pages/cc-view404.js');
+      break;
+  }
+  dispatch(updatePage(page));
+}
+
+const updatePage = (page) => {
+  return {
+    type: UPDATE_PAGE,
+    page
+  };
+}
+
+let snackbarTimer;
+
+export const showSnackbar = () => (dispatch) => {
+  dispatch({
+    type: OPEN_SNACKBAR
+  });
+  clearTimeout(snackbarTimer);
+  snackbarTimer = setTimeout(() =>
+    dispatch({ type: CLOSE_SNACKBAR }), 3000);
+};
+
+export const updateOffline = (offline) => {
+  return {
+    type: UPDATE_OFFLINE,
+    offline
+  };
+};
+

--- a/src/actions/domains/status.js
+++ b/src/actions/domains/status.js
@@ -5,40 +5,39 @@ export const CANCEL_ALLOCATE_ENERGY = 'CANCEL_ALLOCATE_ENERGY';
 export const SET_STATUS = 'SET_STATUS';
 export const SET_PLAYER_HEALTH = 'SET_PLAYER_HEALTH';
 
-export const ResetEnergy = () => {
+export const resetEnergy = () => {
   return {
     type: RESET_ENERGY
   }
 };
 
-export const SpendAllocatedEnergy = (energyCost) => {
+export const spendAllocatedEnergy = () => {
   return {
-    type: SPEND_ALLOCATED_ENERGY,
-    energyCost
+    type: SPEND_ALLOCATED_ENERGY
   }
 };
 
-export const AllocateEnergy = (energyCost) => {
+export const allocateEnergy = (energyCost) => {
   return {
     type: ALLOCATE_ENERGY,
     energyCost
   }
 };
 
-export const CancelAllocateEnergy = () => {
+export const cancelAllocateEnergy = () => {
   return {
     type: CANCEL_ALLOCATE_ENERGY
   }
 };
 
-export const SetStatus = (status) => {
+export const setStatus = (status) => {
   return {
     type: SET_STATUS,
     status
   }
 };
 
-export const SetPlayerHealth = (health) => {
+export const setPlayerHealth = (health) => {
   return {
     type: SET_PLAYER_HEALTH,
     health

--- a/src/actions/domains/turnaction.js
+++ b/src/actions/domains/turnaction.js
@@ -1,17 +1,3 @@
-import { CallEndTurn } from '../../services/turnaction.js';
-import { CallGetHand, CallGetOpponentField } from '../../services/card.js';
-import { 
-  setHand,
-  refreshCards,
-  setOpponentField,
-  setFieldFromOpponentTurn } from './card.js';
-import { 
-  resetEnergy,
-  setPlayerHealth } from './status.js';
-import {
-  loseGame,
-  winGame } from './game.js';
-
 export const RECORD_ATTACK_CARD = 'RECORD_ATTACK_CARD';
 export const RECORD_PLACE_ON_PLAY_AREA = 'RECORD_PLACE_ON_PLAY_AREA';
 export const BEGIN_TURN = 'BEGIN_TURN';
@@ -70,42 +56,7 @@ export const beginTurn = () => {
   }
 }
 
-export const endTurn = (turn) => (dispatch) => {
-  dispatch(_endTurn(turn))
-  CallEndTurn(turn)
-    .then(results => {
-      dispatch(setPlayerHealth(results.remainingPlayerHealth))
-      if (results.remainingPlayerHealth <= 0) {
-        dispatch(loseGame())
-      }
-      dispatch(setFieldFromOpponentTurn(results.opponentTurn))
-      dispatch(appendOpponentHistory(results.opponentTurn))
-      dispatch(appendPlayerHistory(turn))
-      dispatch(beginTurn())
-      dispatch(resetEnergy())
-      dispatch(refreshCards())
-      CallGetHand()
-      .then(hand => dispatch(setHand(hand)))
-      .catch(err => console.error(err))
-      CallGetOpponentField()
-      .then(result => {
-        dispatch(setOpponentField(result))
-        if (!result.opponentField[0].id && !result.opponentField[1].id && !result.opponentField[2].id) {
-          dispatch(winGame())
-        }
-      })
-      .catch(err => console.error(err))
-    })
-    .catch(err => {
-      console.error(err)
-      dispatch(appendPlayerHistory(turn))
-      dispatch(beginTurn())
-      dispatch(resetEnergy())
-      dispatch(refreshCards())
-    })
-}
-
-const _endTurn = () => {
+export const endTurn = () => {
   return {
     type: END_TURN
   }

--- a/src/actions/domains/turnaction.js
+++ b/src/actions/domains/turnaction.js
@@ -1,16 +1,16 @@
-import { CallEndTurn } from '../services/turnaction.js';
-import { CallGetHand, CallGetOpponentField } from '../services/card.js';
+import { CallEndTurn } from '../../services/turnaction.js';
+import { CallGetHand, CallGetOpponentField } from '../../services/card.js';
 import { 
-  SetHand,
-  RefreshCards,
-  SetOpponentField,
-  SetFieldFromOpponentTurn } from './card.js';
+  setHand,
+  refreshCards,
+  setOpponentField,
+  setFieldFromOpponentTurn } from './card.js';
 import { 
-  ResetEnergy,
-  SetPlayerHealth } from './status.js';
+  resetEnergy,
+  setPlayerHealth } from './status.js';
 import {
-  LoseGame,
-  WinGame } from './game.js';
+  loseGame,
+  winGame } from './game.js';
 
 export const RECORD_ATTACK_CARD = 'RECORD_ATTACK_CARD';
 export const RECORD_PLACE_ON_PLAY_AREA = 'RECORD_PLACE_ON_PLAY_AREA';
@@ -23,7 +23,7 @@ export const RECORD_CAST_FROM_HAND = 'RECORD_CAST_FROM_HAND';
 export const RECORD_CAST_FROM_PLAY_AREA = 'RECORD_CAST_FROM_PLAY_AREA';
 export const RECORD_CAST_ABILITY_ENERGIZE = 'RECORD_CAST_ABILITY_ENERGIZE';
 
-export const RecordAttackCard = (playerFieldCardIndex, opponentFieldCardIndex) => {
+export const recordAttackCard = (playerFieldCardIndex, opponentFieldCardIndex) => {
   return {
     type: RECORD_ATTACK_CARD,
     playerFieldCardIndex,
@@ -31,7 +31,7 @@ export const RecordAttackCard = (playerFieldCardIndex, opponentFieldCardIndex) =
   }
 };
 
-export const RecordPlaceOnPlayArea = (playerFieldCardIndex, handCardIndex) => {
+export const recordPlaceOnPlayArea = (playerFieldCardIndex, handCardIndex) => {
   return {
     type: RECORD_PLACE_ON_PLAY_AREA,
     playerFieldCardIndex,
@@ -39,7 +39,7 @@ export const RecordPlaceOnPlayArea = (playerFieldCardIndex, handCardIndex) => {
   }
 };
 
-export const RecordCastFromHand = (cardId, cardInstance, handCardIndex) => {
+export const recordCastFromHand = (cardId, cardInstance, handCardIndex) => {
   return {
     type: RECORD_CAST_FROM_HAND,
     handCardIndex,
@@ -48,7 +48,7 @@ export const RecordCastFromHand = (cardId, cardInstance, handCardIndex) => {
   }
 };
 
-export const RecordCastFromPlayArea = (cardId, cardInstance, playerFieldCardIndex) => {
+export const recordCastFromPlayArea = (cardId, cardInstance, playerFieldCardIndex) => {
   return {
     type: RECORD_CAST_FROM_PLAY_AREA,
     playerFieldCardIndex,
@@ -57,51 +57,51 @@ export const RecordCastFromPlayArea = (cardId, cardInstance, playerFieldCardInde
   }
 };
 
-export const RecordCastAbilityEnergize = (abilityId) => {
+export const recordCastAbilityEnergize = (abilityId) => {
   return {
     type: RECORD_CAST_ABILITY_ENERGIZE,
     abilityId
   }
 };
 
-export const BeginTurn = () => {
+export const beginTurn = () => {
   return {
     type: BEGIN_TURN
   }
 }
 
-export const EndTurn = (turn) => (dispatch) => {
+export const endTurn = (turn) => (dispatch) => {
   dispatch(_endTurn(turn))
   CallEndTurn(turn)
     .then(results => {
-      dispatch(SetPlayerHealth(results.remainingPlayerHealth))
+      dispatch(setPlayerHealth(results.remainingPlayerHealth))
       if (results.remainingPlayerHealth <= 0) {
-        dispatch(LoseGame())
+        dispatch(loseGame())
       }
-      dispatch(SetFieldFromOpponentTurn(results.opponentTurn))
-      dispatch(AppendOpponentHistory(results.opponentTurn))
-      dispatch(AppendPlayerHistory(turn))
-      dispatch(BeginTurn())
-      dispatch(ResetEnergy())
-      dispatch(RefreshCards())
+      dispatch(setFieldFromOpponentTurn(results.opponentTurn))
+      dispatch(appendOpponentHistory(results.opponentTurn))
+      dispatch(appendPlayerHistory(turn))
+      dispatch(beginTurn())
+      dispatch(resetEnergy())
+      dispatch(refreshCards())
       CallGetHand()
-      .then(hand => dispatch(SetHand(hand)))
+      .then(hand => dispatch(setHand(hand)))
       .catch(err => console.error(err))
       CallGetOpponentField()
       .then(result => {
-        dispatch(SetOpponentField(result))
+        dispatch(setOpponentField(result))
         if (!result.opponentField[0].id && !result.opponentField[1].id && !result.opponentField[2].id) {
-          dispatch(WinGame())
+          dispatch(winGame())
         }
       })
       .catch(err => console.error(err))
     })
     .catch(err => {
       console.error(err)
-      dispatch(AppendPlayerHistory(turn))
-      dispatch(BeginTurn())
-      dispatch(ResetEnergy())
-      dispatch(RefreshCards())
+      dispatch(appendPlayerHistory(turn))
+      dispatch(beginTurn())
+      dispatch(resetEnergy())
+      dispatch(refreshCards())
     })
 }
 
@@ -111,21 +111,21 @@ const _endTurn = () => {
   }
 }
 
-export const AppendPlayerHistory = (turn) => {
+export const appendPlayerHistory = (turn) => {
   return {
     type: APPEND_PLAYER_HISTORY,
     turn
   }
 }
 
-export const AppendOpponentHistory = (turn) => {
+export const appendOpponentHistory = (turn) => {
   return {
     type: APPEND_OPPONENT_HISTORY,
     turn
   }
 }
 
-export const ResetTurns = () => {
+export const resetTurns = () => {
   return {
     type: RESET_TURNS
   }

--- a/src/app/cc-app.js
+++ b/src/app/cc-app.js
@@ -14,7 +14,7 @@ import { installRouter } from 'pwa-helpers/router';
 import { installOfflineWatcher } from 'pwa-helpers/network';
 
 import { store } from '../store.js';
-import { navigate, updateOffline, showSnackbar } from '../actions/app.js';
+import { Navigate, UpdateOffline, ShowSnackbar } from '../actions/app.js';
 
 import '../components/cc-snack-bar.js';
 import { CcSharedStyles } from '../components/global/cc-shared-styles.js';
@@ -84,12 +84,12 @@ class CcApp extends connect(store)(LitElement) {
     if (this._offline === undefined || this._offline == offline) {
       return;
     }
-    store.dispatch(updateOffline(offline));
-    store.dispatch(showSnackbar());
+    store.dispatch(UpdateOffline(offline));
+    store.dispatch(ShowSnackbar());
   }
 
   _locationChanged(location) {
-    store.dispatch(navigate(window.decodeURIComponent(location.pathname)));
+    store.dispatch(Navigate(window.decodeURIComponent(location.pathname)));
   }
 }
 

--- a/src/app/pages/cc-game-page.js
+++ b/src/app/pages/cc-game-page.js
@@ -18,7 +18,7 @@ import '../../components/menus/cc-end-game-pane.js';
 import '../../components/play-area/cc-play-area.js';
 import '../../components/toolbars/cc-game-footer.js';
 import '../../components/toolbars/cc-game-header.js';
-import { ResetGame } from '../../actions/game.js';
+import { ResetGame } from '../../actions/app.js';
 import { GAME_STATE_PLAYING } from '../../reducers/game.js';
 
 export class CcGamePage extends connect(store)(CcPageViewElement) {

--- a/src/components/cards/card-groups/cc-card-hand.js
+++ b/src/components/cards/card-groups/cc-card-hand.js
@@ -7,7 +7,7 @@ import { store } from '../../../store.js';
 import '../card-types/cc-mini-card.js';
 
 import { 
-  SelectHandCard } from '../../../actions/card.js';
+  SelectHandCard } from '../../../actions/app.js';
 
 export class CcCardHand extends connect(store)(LitElement) {
   _render({_selectedCard, _hand}) {

--- a/src/components/cards/card-groups/cc-cast-card-pane.js
+++ b/src/components/cards/card-groups/cc-cast-card-pane.js
@@ -6,16 +6,12 @@ import { store } from '../../../store.js';
 
 import {
   CancelCastingCard,
-  FinishCastingCard } from '../../../actions/card.js';
-
-import { 
+  FinishCastingCard,
   CancelAllocateEnergy,
-  SpendAllocatedEnergy } from '../../../actions/status.js';
-
-import { 
+  SpendAllocatedEnergy,
   RecordCastFromHand,
   RecordCastFromPlayArea,
-  RecordCastAbilityEnergize } from '../../../actions/turnaction.js';
+  RecordCastAbilityEnergize } from '../../../actions/app.js';
 
 import { ABILITY_ENERGIZE } from '../../../util/card-constants.js';  
 

--- a/src/components/cards/card-groups/cc-cast-card-pane.js
+++ b/src/components/cards/card-groups/cc-cast-card-pane.js
@@ -7,11 +7,9 @@ import { store } from '../../../store.js';
 import {
   CancelCastingCard,
   FinishCastingCard,
-  CancelAllocateEnergy,
-  SpendAllocatedEnergy,
-  RecordCastFromHand,
-  RecordCastFromPlayArea,
-  RecordCastAbilityEnergize } from '../../../actions/app.js';
+  CastFromHand,
+  CastFromPlayArea,
+  CastAbilityEnergize } from '../../../actions/app.js';
 
 import { ABILITY_ENERGIZE } from '../../../util/card-constants.js';  
 
@@ -96,13 +94,11 @@ export class CcCastCardPane extends connect(store)(LitElement) {
   }
 
   _cancel() {
-    store.dispatch(CancelAllocateEnergy())
     store.dispatch(CancelCastingCard())
   }
 
   _done() {
     store.dispatch(FinishCastingCard())
-    store.dispatch(SpendAllocatedEnergy())
   }
 
   _getAbilitiesHtml() {
@@ -121,16 +117,16 @@ export class CcCastCardPane extends connect(store)(LitElement) {
 
   _castAbility(ability) {
     if (this._handIndex === 0 || this._handIndex) {
-      store.dispatch(RecordCastFromHand(this._cardId, this._cardInstance, this._handIndex))
+      store.dispatch(CastFromHand(this._cardId, this._cardInstance, this._handIndex))
     } else if (this._playFieldIndex === 0 || this._playFieldIndex) {
-      store.dispatch(RecordCastFromPlayArea(this._cardId, this._cardInstance, this._playFieldIndex))
+      store.dispatch(CastFromPlayArea(this._cardId, this._cardInstance, this._playFieldIndex))
     } else {
       console.error('Unexpected casting origin: not from hand nor play area.')
       return
     }
     switch (ability.id) {
       case ABILITY_ENERGIZE:
-        return store.dispatch(RecordCastAbilityEnergize(ability.id))
+        return store.dispatch(CastAbilityEnergize(ability.id))
       default:
         console.error(`Unexpected ability: ${ability.id}`)
         return

--- a/src/components/cards/card-groups/cc-cast-card-pane.js
+++ b/src/components/cards/card-groups/cc-cast-card-pane.js
@@ -7,8 +7,6 @@ import { store } from '../../../store.js';
 import {
   CancelCastingCard,
   FinishCastingCard,
-  CastFromHand,
-  CastFromPlayArea,
   CastAbilityEnergize } from '../../../actions/app.js';
 
 import { ABILITY_ENERGIZE } from '../../../util/card-constants.js';  
@@ -72,25 +70,20 @@ export class CcCastCardPane extends connect(store)(LitElement) {
   }
 
   static get properties() { return {
-    _selectedCard: Object,
-    _cannotAfford: Boolean,
-    _cardId: String,
-    _cardInstance: String,
-    _handIndex: Number
+    _selectedCard: Object
   }};
 
   _stateChanged(state) {
-    this._cardId = state.card.selectedCastingCard.id
-    this._cardInstance = state.card.selectedCastingCard.instance
-    this._handIndex = state.card.selectedCastingCard.handIndex
-    if (!this._cardId) {
+    const cardId = state.card.selectedCastingCard.id
+    const cardInstance = state.card.selectedCastingCard.instance
+    if (!cardId) {
       this._selectedCard = {
         version: 0,
         abilities: []
       }
       return
     }
-    this._selectedCard = state.card.cards[this._cardId].instances[this._cardInstance]
+    this._selectedCard = state.card.cards[cardId].instances[cardInstance]
   }
 
   _cancel() {
@@ -116,14 +109,6 @@ export class CcCastCardPane extends connect(store)(LitElement) {
   }
 
   _castAbility(ability) {
-    if (this._handIndex === 0 || this._handIndex) {
-      store.dispatch(CastFromHand(this._cardId, this._cardInstance, this._handIndex))
-    } else if (this._playFieldIndex === 0 || this._playFieldIndex) {
-      store.dispatch(CastFromPlayArea(this._cardId, this._cardInstance, this._playFieldIndex))
-    } else {
-      console.error('Unexpected casting origin: not from hand nor play area.')
-      return
-    }
     switch (ability.id) {
       case ABILITY_ENERGIZE:
         return store.dispatch(CastAbilityEnergize(ability.id))

--- a/src/components/cards/card-groups/cc-hand-card-pane.js
+++ b/src/components/cards/card-groups/cc-hand-card-pane.js
@@ -6,10 +6,8 @@ import { store } from '../../../store.js';
 
 import { 
   CancelSelectHandCard,
-  PlaySelectedHandCard } from '../../../actions/card.js';
-
-import {
-  AllocateEnergy } from '../../../actions/status.js';
+  PlaySelectedHandCard,
+  AllocateEnergy } from '../../../actions/app.js';
 
 import { PLAYER_OWNER } from '../../../util/owner.js';  
 

--- a/src/components/cards/card-groups/cc-hand-card-pane.js
+++ b/src/components/cards/card-groups/cc-hand-card-pane.js
@@ -6,8 +6,7 @@ import { store } from '../../../store.js';
 
 import { 
   CancelSelectHandCard,
-  PlaySelectedHandCard,
-  AllocateEnergy } from '../../../actions/app.js';
+  PlaySelectedHandCard } from '../../../actions/app.js';
 
 import { PLAYER_OWNER } from '../../../util/owner.js';  
 
@@ -60,7 +59,6 @@ export class CcHandCardPane extends connect(store)(LitElement) {
   }
 
   _play() {
-    store.dispatch(AllocateEnergy(this._selectedCard.cost))
     store.dispatch(PlaySelectedHandCard())
   }
 

--- a/src/components/cards/card-groups/cc-opponent-card-pane.js
+++ b/src/components/cards/card-groups/cc-opponent-card-pane.js
@@ -5,7 +5,7 @@ import { connect } from 'pwa-helpers/connect-mixin';
 import { store } from '../../../store.js';
 
 import { 
-  CancelSelectOpponentFieldCard } from '../../../actions/card.js';
+  CancelSelectOpponentFieldCard } from '../../../actions/app.js';
 
 import { OPPONENT_OWNER } from '../../../util/owner.js';
 

--- a/src/components/cards/card-groups/cc-pawn-card-pane.js
+++ b/src/components/cards/card-groups/cc-pawn-card-pane.js
@@ -3,7 +3,7 @@ import { CcSharedStyles } from '../../global/cc-shared-styles.js';
 
 import { store } from '../../../store.js';
 
-import { CancelPlayFromPlayArea } from '../../../actions/card.js';
+import { CancelPlayFromPlayArea } from '../../../actions/app.js';
 
 import '../../global/cc-btn.js';
 

--- a/src/components/cards/card-groups/cc-place-card-pane.js
+++ b/src/components/cards/card-groups/cc-place-card-pane.js
@@ -4,8 +4,7 @@ import { CcSharedStyles } from '../../global/cc-shared-styles.js';
 import { store } from '../../../store.js';
 
 import { 
-  CancelPlaySelectedHandCard,
-  CancelAllocateEnergy } from '../../../actions/app.js';
+  CancelPlaySelectedHandCard } from '../../../actions/app.js';
 
 import '../../global/cc-btn.js';
 
@@ -47,7 +46,6 @@ export class CcPlaceCardPane extends LitElement {
   }
 
   _cancel() {
-    store.dispatch(CancelAllocateEnergy())
     store.dispatch(CancelPlaySelectedHandCard())
   }
 }

--- a/src/components/cards/card-groups/cc-place-card-pane.js
+++ b/src/components/cards/card-groups/cc-place-card-pane.js
@@ -3,9 +3,9 @@ import { CcSharedStyles } from '../../global/cc-shared-styles.js';
 
 import { store } from '../../../store.js';
 
-import { CancelPlaySelectedHandCard } from '../../../actions/card.js';
-
-import { CancelAllocateEnergy } from '../../../actions/status.js';
+import { 
+  CancelPlaySelectedHandCard,
+  CancelAllocateEnergy } from '../../../actions/app.js';
 
 import '../../global/cc-btn.js';
 

--- a/src/components/cards/card-groups/cc-unit-card-pane.js
+++ b/src/components/cards/card-groups/cc-unit-card-pane.js
@@ -5,7 +5,7 @@ import { connect } from 'pwa-helpers/connect-mixin';
 import { store } from '../../../store.js';
 
 import { 
-  CancelSelectPlayerFieldCard } from '../../../actions/card.js';
+  CancelSelectPlayerFieldCard } from '../../../actions/app.js';
 
 import { PLAYER_OWNER } from '../../../util/owner.js';
 

--- a/src/components/menus/cc-end-game-pane.js
+++ b/src/components/menus/cc-end-game-pane.js
@@ -4,9 +4,7 @@ import { CcSharedStyles } from '../global/cc-shared-styles.js';
 import { connect } from 'pwa-helpers/connect-mixin';
 import { store } from '../../store.js';
 
-import { 
-  HideInGameMenu,
-  ResetGame } from '../../actions/app.js';
+import { ResetGame } from '../../actions/app.js';
 
 import {
   GAME_STATE_LOSE,
@@ -59,7 +57,6 @@ export class CcEndGamePane extends connect(store)(LitElement) {
   }
 
   _resetGame() {
-    store.dispatch(HideInGameMenu())
     store.dispatch(ResetGame())
   }
 }

--- a/src/components/menus/cc-end-game-pane.js
+++ b/src/components/menus/cc-end-game-pane.js
@@ -6,7 +6,7 @@ import { store } from '../../store.js';
 
 import { 
   HideInGameMenu,
-  ResetGame } from '../../actions/game.js';
+  ResetGame } from '../../actions/app.js';
 
 import {
   GAME_STATE_LOSE,

--- a/src/components/menus/cc-game-menu-pane.js
+++ b/src/components/menus/cc-game-menu-pane.js
@@ -43,7 +43,6 @@ export class CcGameMenuPane extends LitElement {
   }
 
   _resetGame() {
-    store.dispatch(HideInGameMenu())
     store.dispatch(ResetGame())
   }
 }

--- a/src/components/menus/cc-game-menu-pane.js
+++ b/src/components/menus/cc-game-menu-pane.js
@@ -5,7 +5,7 @@ import { store } from '../../store.js';
 
 import { 
   HideInGameMenu,
-  ResetGame } from '../../actions/game.js';
+  ResetGame } from '../../actions/app.js';
 
 import '../global/cc-btn.js';
 

--- a/src/components/play-area/cc-play-field.js
+++ b/src/components/play-area/cc-play-field.js
@@ -17,10 +17,7 @@ import {
   PlayFromPlayArea,
   SelectOpponentFieldCard,
   SelectPlayerFieldCard,
-  AttackCard,
-  SpendAllocatedEnergy,
-  RecordAttackCard,
-  RecordPlaceOnPlayArea } from '../../actions/app.js';
+  AttackCard } from '../../actions/app.js';
 
 export class CcPlayField extends connect(store)(LitElement) {
   _render({_leftCard, _middleCard, _rightCard, overlay, _totalCardVersion}) {
@@ -56,7 +53,6 @@ export class CcPlayField extends connect(store)(LitElement) {
     _middleCard: Object,
     _attackingCard: Object,
     _replacingCard: Object,
-    _handCardIndex: Number,
     _playingFromPlayAreaIndex: Number,
     _totalCardVersion: Number // meant soley to force an update, if need be
   }};
@@ -71,7 +67,6 @@ export class CcPlayField extends connect(store)(LitElement) {
     }
     if (state.card.playFromHand.id) {
       this._replacingCard = state.card.cards[state.card.playFromHand.id].instances[state.card.playFromHand.instance]
-      this._handCardIndex = state.card.playFromHand.handIndex
     } else {
       this._replacingCard = null      
     }
@@ -212,27 +207,19 @@ export class CcPlayField extends connect(store)(LitElement) {
   }
 
   _attackCard(card, playAreaIndex) {
-    const hardCodedPlayerPlayAreaIndex = this._playingFromPlayAreaIndex
     return html`
       <cc-attack-card
           attacked="${card}"
           attacking="${this._attackingCard}"
-          on-click="${() => {
-            store.dispatch(AttackCard(playAreaIndex))
-            store.dispatch(RecordAttackCard(hardCodedPlayerPlayAreaIndex, playAreaIndex))
-          }}"></cc-attack-card>`
+          on-click="${() => store.dispatch(AttackCard(playAreaIndex))}"></cc-attack-card>`
   }
 
-  _replaceCard(card, playAreaIndex, handCardIndex) {
+  _replaceCard(card, playAreaIndex) {
     return html`
       <cc-replace-card
           replaced="${card}"
           replacing="${this._replacingCard}"
-          on-click="${() => {
-            store.dispatch(SpendAllocatedEnergy())
-            store.dispatch(PlaceOnPlayArea(playAreaIndex))
-            store.dispatch(RecordPlaceOnPlayArea(playAreaIndex, this._handCardIndex))
-          }}"></cc-replace-card>`
+          on-click="${() => store.dispatch(PlaceOnPlayArea(playAreaIndex))}"></cc-replace-card>`
   }
 
   _playerPawnCard(card, playAreaIndex) {

--- a/src/components/play-area/cc-play-field.js
+++ b/src/components/play-area/cc-play-field.js
@@ -17,14 +17,10 @@ import {
   PlayFromPlayArea,
   SelectOpponentFieldCard,
   SelectPlayerFieldCard,
-  AttackCard } from '../../actions/card.js';
-
-import {
-  SpendAllocatedEnergy } from '../../actions/status.js';
-
-import {
-  RecordPlaceOnPlayArea,
-  RecordAttackCard } from '../../actions/turnaction.js'; 
+  AttackCard,
+  SpendAllocatedEnergy,
+  RecordAttackCard,
+  RecordPlaceOnPlayArea } from '../../actions/app.js';
 
 export class CcPlayField extends connect(store)(LitElement) {
   _render({_leftCard, _middleCard, _rightCard, overlay, _totalCardVersion}) {

--- a/src/components/toolbars/cc-game-footer.js
+++ b/src/components/toolbars/cc-game-footer.js
@@ -7,8 +7,9 @@ import './cc-lost-pile-bar-item.js';
 
 import { store } from '../../store.js';
 
-import { EndTurn } from '../../actions/turnaction.js';
-import { ClearHand } from '../../actions/card.js';
+import { 
+  EndTurn,
+  ClearHand } from '../../actions/app.js';
 
 export class CcGameFooter extends LitElement {
   _render() {

--- a/src/components/toolbars/cc-game-footer.js
+++ b/src/components/toolbars/cc-game-footer.js
@@ -8,8 +8,7 @@ import './cc-lost-pile-bar-item.js';
 import { store } from '../../store.js';
 
 import { 
-  EndTurn,
-  ClearHand } from '../../actions/app.js';
+  EndTurn } from '../../actions/app.js';
 
 export class CcGameFooter extends LitElement {
   _render() {
@@ -46,8 +45,7 @@ export class CcGameFooter extends LitElement {
   }};
 
   _endTurn() {
-    store.dispatch(ClearHand())
-    store.dispatch(EndTurn(store.getState().turnaction.pendingTurn))
+    store.dispatch(EndTurn())
   }
 }
 

--- a/src/components/toolbars/cc-game-header.js
+++ b/src/components/toolbars/cc-game-header.js
@@ -6,7 +6,7 @@ import { store } from '../../store.js';
 import './cc-energy-bar-item.js';
 import './cc-health-bar-item.js';
 import './cc-game-menu-bar-item.js';
-import { ShowInGameMenu } from '../../actions/game.js';
+import { ShowInGameMenu } from '../../actions/app.js';
 
 export class CcGameHeader extends LitElement {
   _render() {

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 
 import { UPDATE_PAGE, UPDATE_OFFLINE,
-         OPEN_SNACKBAR, CLOSE_SNACKBAR } from '../actions/app.js';
+         OPEN_SNACKBAR, CLOSE_SNACKBAR } from '../actions/domains/page.js';
 
 const app = (state = {}, action) => {
   switch (action.type) {

--- a/src/reducers/card.js
+++ b/src/reducers/card.js
@@ -19,7 +19,7 @@ import {
   SET_FIELD_FROM_OPPONENT_TURN,
   RESET_CARDS,
   CANCEL_CASTING_CARD,
-  FINISH_CASTING_CARD } from '../actions/card.js';
+  FINISH_CASTING_CARD } from '../actions/domains/card.js';
 
 import {
   PlaceOnPlayAreaResults,

--- a/src/reducers/game.js
+++ b/src/reducers/game.js
@@ -3,7 +3,7 @@ import {
   HIDE_IN_GAME_MENU,
   RESET_GAME,
   WIN_GAME,
-  LOSE_GAME } from '../actions/game.js';
+  LOSE_GAME } from '../actions/domains/game.js';
 
 export const GAME_STATE_PLAYING = 'playing';
 export const GAME_STATE_LOSE = 'lose';

--- a/src/reducers/status.js
+++ b/src/reducers/status.js
@@ -4,7 +4,7 @@ import {
   ALLOCATE_ENERGY,
   CANCEL_ALLOCATE_ENERGY,
   SET_STATUS,
-  SET_PLAYER_HEALTH } from '../actions/status.js';
+  SET_PLAYER_HEALTH } from '../actions/domains/status.js';
 
 const defaultState = {
   energy: {

--- a/src/reducers/turnaction.js
+++ b/src/reducers/turnaction.js
@@ -7,13 +7,13 @@ import {
   BEGIN_TURN,
   RECORD_CAST_FROM_HAND,
   RECORD_CAST_FROM_PLAY_AREA,
-  RECORD_CAST_ABILITY_ENERGIZE } from '../actions/turnaction.js';
+  RECORD_CAST_ABILITY_ENERGIZE } from '../actions/domains/turnaction.js';
 
 import {
   ATTACK_CARD,
   PLACE_ON_PLAY_AREA,
   CAST_CARD_FROM_HAND,
-  CAST_CARD_FROM_PLAY_AREA } from '../actions/card.js';
+  CAST_CARD_FROM_PLAY_AREA } from '../actions/domains/card.js';
 
 
 export const FIRST_TURN_PLAYER = 'player';

--- a/src/services/mock/storage/turn-actions.js
+++ b/src/services/mock/storage/turn-actions.js
@@ -1,6 +1,6 @@
 import {
   ATTACK_CARD,
-  PLACE_ON_PLAY_AREA } from '../../../actions/card.js';
+  PLACE_ON_PLAY_AREA } from '../../../actions/domains/card.js';
 
 import {
   PlaceOnPlayAreaResults,

--- a/src/util/opponent-turn.js
+++ b/src/util/opponent-turn.js
@@ -8,7 +8,7 @@ import {
 
 import { 
   ATTACK_CARD,
-  ATTACK_PLAYER } from '../actions/card.js';
+  ATTACK_PLAYER } from '../actions/domains/card.js';
 
 const MAX_LOOP_ITERATIONS = 10;
 


### PR DESCRIPTION
Components were getting congested with too much logic.  This was because there was a 1:1 of actions and reducers.  Since reducers cannot share state with other reducers, if complex actions required interacting with several reducers that logic had to be handled in the component.

The solution was to create a parent action which is intended to handle actions from components, then it handles the logic of dispatching across multiple 1:1 action/reducers.

This should be very helpful for maintainability in the future (if logic is added to click actions, just include it in the parent action file (`actions/app.js`).  It should also help with casting abilities, which had complexity due to determining if it was being cast from hand vs playfield and whether it was the same card or a new card being cast.